### PR TITLE
Added docHeader option and fixed combined.json concat bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ function ScreenshotReporter(options) {
 
 	this.pathBuilder = options.pathBuilder || defaultPathBuilder;
 	this.docTitle = options.docTitle || 'Generated test report';
+	this.docHeader = options.docHeader || 'Test Results';
 	this.docName = options.docName || 'report.html';
 	this.metaDataBuilder = options.metaDataBuilder || defaultMetaDataBuilder;
 	this.preserveDirectory = options.preserveDirectory || false;
@@ -123,6 +124,7 @@ function ScreenshotReporter(options) {
  		pathBuilder: this.pathBuilder,
  		baseDirectory: this.baseDirectory,
  		docTitle: this.docTitle,
+ 		docHeader: this.docHeader,
  		docName: this.docName,
  		cssOverrideFile: this.cssOverrideFile
  	};
@@ -130,6 +132,10 @@ function ScreenshotReporter(options) {
  	if(!this.preserveDirectory){
  		util.removeDirectory(this.finalOptions.baseDirectory);
  	}
+
+	//remove combined.json if it exists, so many reports can be created in the same html file
+ 	var combinedFile = path.join(this.finalOptions.baseDirectory,'combined.json');
+	util.removeFile(combinedFile);
 }
 
 /** Function: reportSpecResults

--- a/lib/jsonparser.js
+++ b/lib/jsonparser.js
@@ -61,7 +61,7 @@ phssr.makeHTMLPage = function(tableHtml, reporterOptions){
     }
 
     staticHTMLContentprefix +=  styleTag + scrpTag + " </head><body>";
-    staticHTMLContentprefix +=  "<h1>Test Results</h1><table class='header'>";
+    staticHTMLContentprefix +=  "<h1>" + reporterOptions.docHeader + "</h1><table class='header'>";
     staticHTMLContentprefix +=  "<tr><th class='desc-col'>Description</th><th class='status-col'>Passed</th>";
     staticHTMLContentprefix +=  "<th class='browser-col'>Browser</th>";
     staticHTMLContentprefix +=  "<th class='os-col'>OS</th><th class='msg-col'>Message</th>";

--- a/lib/util.js
+++ b/lib/util.js
@@ -32,10 +32,12 @@ function addHTMLReport(jsonData, baseName, options){
 }
 
 function addMetaData(metaData, baseName, descriptions, options){
+
 	var json,
 		stream,
 		basePath = path.dirname(baseName),
 		file = path.join(basePath,'combined.json');
+
 	try {
 		metaData.description = descriptions.join('|');
 		json = metaData;
@@ -155,6 +157,12 @@ function removeDirectory(dirPath){
       fs.rmdirSync(dirPath);
 };
 
+function removeFile(filePath){
+		if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()){
+			fs.unlinkSync(filePath);
+		}
+};
+
 module.exports = {
 	storeScreenShot: storeScreenShot
 	, storeMetaData: storeMetaData
@@ -162,4 +170,5 @@ module.exports = {
 	, generateGuid: generateGuid
 	, addMetaData: addMetaData
 	, removeDirectory: removeDirectory
+	, removeFile: removeFile
 };


### PR DESCRIPTION
Added docHeader option so the h1 at the top of the report can be customized. Remove combined.json after each test session, so multiple reports can utilize the same screenshot baseDirectory without concatenating eachother's report data into the most recent report.