### PR TITLE
Add option disableMetaData to skip json storage

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,14 +56,14 @@ function defaultMetaDataBuilder(spec, descriptions, results, capabilities) {
 			var failedItem = _.where(results.items_,{passed_: false})[0];
 			if(failedItem){
 				metaData.message = failedItem.message || 'Failed';
-				metaData.trace = failedItem.trace? (failedItem.trace.stack || 'No Stack trace information') : 'No Stack trace information';	
+				metaData.trace = failedItem.trace? (failedItem.trace.stack || 'No Stack trace information') : 'No Stack trace information';
 			}
 
 		}else{
 			metaData.message = result.message || 'Passed';
 			metaData.trace = result.trace.stack;
 		}
-		
+
 	}
 
 	return metaData;
@@ -108,7 +108,10 @@ function ScreenshotReporter(options) {
 	}
 
 	this.pathBuilder = options.pathBuilder || defaultPathBuilder;
+	this.disableMetaData = options.disableMetaData || false;
+	this.combinedJsonFileName = options.combinedJsonFileName || 'combined.json';
 	this.docTitle = options.docTitle || 'Generated test report';
+	this.docHeader = options.docHeader || 'Test Results';
 	this.docName = options.docName || 'report.html';
 	this.metaDataBuilder = options.metaDataBuilder || defaultMetaDataBuilder;
 	this.preserveDirectory = options.preserveDirectory || false;
@@ -121,8 +124,11 @@ function ScreenshotReporter(options) {
  		takeScreenShotsForSkippedSpecs: this.takeScreenShotsForSkippedSpecs,
  		metaDataBuilder: this.metaDataBuilder,
  		pathBuilder: this.pathBuilder,
+ 		disableMetaData: this.disableMetaData,
+ 		combinedJsonFileName: this.combinedJsonFileName,
  		baseDirectory: this.baseDirectory,
  		docTitle: this.docTitle,
+ 		docHeader: this.docHeader,
  		docName: this.docName,
  		cssOverrideFile: this.cssOverrideFile
  	};
@@ -187,8 +193,10 @@ function reportSpecResults(spec) {
 					util.addMetaData(metaData, metaDataPath, descriptions, self.finalOptions);
 					if(!(self.takeScreenShotsOnlyForFailedSpecs && results.passed())) {
 						util.storeScreenShot(png, screenShotPath);
-					}	
-					util.storeMetaData(metaData, metaDataPath);
+					}
+					if (!self.finalOptions.disableMetaData) {
+						util.storeMetaData(metaData, metaDataPath);
+					}
 				}
 			});
 		});

--- a/lib/jsonparser.js
+++ b/lib/jsonparser.js
@@ -1,5 +1,5 @@
 var _ = require('underscore'),
-    path = require('path'), 
+    path = require('path'),
     reporterOptions;
 
 //create a namespace for these functions, so they do not conflict with other scripts
@@ -61,7 +61,7 @@ phssr.makeHTMLPage = function(tableHtml, reporterOptions){
     }
 
     staticHTMLContentprefix +=  styleTag + scrpTag + " </head><body>";
-    staticHTMLContentprefix +=  "<h1>Test Results</h1><table class='header'>";
+    staticHTMLContentprefix +=  "<h1>" + reporterOptions.docHeader + "</h1><table class='header'>";
     staticHTMLContentprefix +=  "<tr><th class='desc-col'>Description</th><th class='status-col'>Passed</th>";
     staticHTMLContentprefix +=  "<th class='browser-col'>Browser</th>";
     staticHTMLContentprefix +=  "<th class='os-col'>OS</th><th class='msg-col'>Message</th>";
@@ -88,12 +88,12 @@ function generateHTML(data){
     str +=  '<td class="msg-col">' + data.message+ stackTraceInfo+ '</td>';
 
     if(!(reporterOptions.takeScreenShotsOnlyForFailedSpecs && data.passed)) {
-        str +=  '<td class="img-col"><a href="#" onclick="openModal(\'' + path.basename(data.screenShotFile)+ '\')">View </a></td>';    
+        str +=  '<td class="img-col"><a href="#" onclick="openModal(\'' + path.basename(data.screenShotFile)+ '\')">View </a></td>';
     }
     else{
-        str +=  '<td class="img-col"></td>';   
+        str +=  '<td class="img-col"></td>';
     }
-    
+
     str += '</tr></table>';
     loopCount++;
     return str;
@@ -208,7 +208,7 @@ function processJson(jsonData, options){
         }
     });
 
-    
+
 
     function parseJSON(element) {
         if(element.children){
@@ -227,7 +227,7 @@ function processJson(jsonData, options){
             });
             return jsonStr;
         }
-        
+
     }
 
     var tableHtml = "";

--- a/lib/util.js
+++ b/lib/util.js
@@ -24,18 +24,18 @@ function addHTMLReport(jsonData, baseName, options){
 	var basePath = path.dirname(baseName),
 		htmlFile = path.join(basePath, options.docName),
 		stream;
-	
+
 	stream = fs.createWriteStream(htmlFile);
 	stream.write(jsonParser.processJson(jsonData, options));
 	stream.end();
-	
+
 }
 
 function addMetaData(metaData, baseName, descriptions, options){
 	var json,
 		stream,
 		basePath = path.dirname(baseName),
-		file = path.join(basePath,'combined.json');
+		file = path.join(basePath, options.combinedJsonFileName);
 	try {
 		metaData.description = descriptions.join('|');
 		json = metaData;
@@ -51,10 +51,10 @@ function addMetaData(metaData, baseName, descriptions, options){
 		}catch(e){
 			json = [json];
 		}
-
 		stream = fs.createWriteStream(file);
 		stream.write(JSON.stringify(json));
 		stream.end();
+
 		addHTMLReport(json, baseName, options);
 	} catch(e) {
 		console.error('Could not save meta data');


### PR DESCRIPTION
Add a few options:
* **disableMetaData** to avoid having ton of json files (just interested in combined json & html files)
* **combinedJsonFileName** to change default `'combined.json'`
* **docHeader** to allow customizing the html default header `'Test Results'`
