### PR TITLE
Fix JavaScript errors in Firefox

### DIFF
--- a/lib/jsonparser.js
+++ b/lib/jsonparser.js
@@ -7,10 +7,10 @@ var phssr = phssr ? phssr : {};
 
 phssr.makeScriptTag = function(){
     var scrpTag = "<script type='text/javascript'>";
-    scrpTag +="function showTrace(e){";
-    scrpTag +="window.event.srcElement.parentElement.getElementsByClassName('traceinfo')[0].className = 'traceinfo visible';}";
-    scrpTag +="function closeTraceModal(e){";
-    scrpTag +="window.event.srcElement.parentElement.parentElement.className = 'traceinfo';}";
+    scrpTag +="function showTrace(event){";
+    scrpTag +="event.target.parentElement.getElementsByClassName('traceinfo')[0].className = 'traceinfo visible';}";
+    scrpTag +="function closeTraceModal(event){";
+    scrpTag +="event.target.parentElement.parentElement.className = 'traceinfo';}";
     scrpTag +="function openModal(imageSource){";
     scrpTag +="var myWindow = window.open('','screenshotWindow');";
     scrpTag +="myWindow.document.write('<img src=\"' +imageSource + '\" alt=\"screenshot\" />');}";
@@ -83,7 +83,7 @@ function generateHTML(data){
     str +=  '<td class="status-col" style="color:#fff;background-color: '+ bgColor+'">' + data.passed + '</td>';
     str +=  '<td class="browser-col">' + data.browser.name+ ':' +data.browser.version + '</td>';
     str +=  '<td class="os-col">' + data.os + '</td>';
-    var stackTraceInfo = data.passed? '': '<br/><a onclick="showTrace()" href="#trace-modal'+loopCount+'">View Stack Trace Info</a><br/> <div id="#trace-modal'+loopCount+'" class="traceinfo"><div><a href="#close" onclick="closeTraceModal()" title="Close" class="close">X</a>' + data.trace + '</div></div>';
+    var stackTraceInfo = data.passed? '': '<br/><a onclick="showTrace(event)" href="#trace-modal'+loopCount+'">View Stack Trace Info</a><br/> <div id="#trace-modal'+loopCount+'" class="traceinfo"><div><a href="#close" onclick="closeTraceModal(event)" title="Close" class="close">X</a>' + data.trace + '</div></div>';
 
     str +=  '<td class="msg-col">' + data.message+ stackTraceInfo+ '</td>';
 


### PR DESCRIPTION
`window.event` and `Event.srcElement` seem to be non-standard and cause errors in Firefox. With these changes opening/closing stacktraces works fine in both Firefox and Chrome.